### PR TITLE
Fix extensions nil

### DIFF
--- a/lib/eassl/certificate.rb
+++ b/lib/eassl/certificate.rb
@@ -55,7 +55,7 @@ module EaSSL
           extensions << ef.create_extension("subjectAltName", subjectAltName)
         end
 
-        if sr = @options[:signing_request]
+        if sr = @options[:signing_request] and not sr.extensions.nil?
           sr.extensions.each do |ext|
             if @options[:override_req] # CA extensions take precedence in merge, default behavior
               extensions << ext unless extensions.any? { |e| e.oid == ext.oid }


### PR DESCRIPTION
Fix when no extensions are present, which results in error:

`/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/eassl3-3.0.1/lib/eassl/certificate.rb:59:in `ssl': undefined method `each' for nil:NilClass (NoMethodError)
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/eassl3-3.0.1/lib/eassl/certificate.rb:78:in `sign'
    from /opt/chef/embedded/lib/ruby/gems/1.9.1/gems/eassl3-3.0.1/lib/eassl/certificate_authority.rb:42:in `create_certificate'`
